### PR TITLE
Fix: Enemies now resume movement after being offscreen.

### DIFF
--- a/src/classes/Enemy.js
+++ b/src/classes/Enemy.js
@@ -91,16 +91,18 @@ export class Enemy {
             this.healthBar.width = 30 * healthPercent;
         }
         
+        // Check if enemy is offscreen for culling
+        this.checkOffscreen();
+        
         // Basic AI - move toward player
-        this.moveTowardPlayer();
+        if (!this.sprite.body.sleeping) {
+            this.moveTowardPlayer();
+        }
         
         // Shooter enemy specific behavior
         if (this.type === 'SHOOTER') {
             this.updateShooterBehavior();
         }
-        
-        // Check if enemy is offscreen for culling
-        this.checkOffscreen();
     }
     
     moveTowardPlayer() {


### PR DESCRIPTION
Previously, enemies would permanently stop moving if they went offscreen because their velocity was set to zero and not restored when they came back onscreen.

This commit modifies the Enemy.update() method to:
1. Call checkOffscreen() before moveTowardPlayer().
2. Only call moveTowardPlayer() if the enemy's physics body is not sleeping. This ensures that an enemy's movement is correctly updated when it transitions from offscreen to onscreen.