### PR TITLE
Fix: Ensure Enemy.update is called and pool recycling is robust

### DIFF
--- a/src/classes/GameScene.js
+++ b/src/classes/GameScene.js
@@ -395,7 +395,7 @@ export class GameScene extends Phaser.Scene {
         // Update each enemy to follow player or do AI behavior
         this.enemies.getChildren().forEach(enemy => {
             if (enemy.active) {
-                enemy.update();
+                enemy.enemy.update();
             }
         });
     }

--- a/src/classes/Spawner.js
+++ b/src/classes/Spawner.js
@@ -149,6 +149,9 @@ export class Spawner {
                     enemy.sprite.x = x;
                     enemy.sprite.y = y;
                     enemy.hp = enemy.maxHp;
+                    enemy.sprite.body.reset(x, y);
+                    enemy.isOffscreen = false;
+                    enemy.sprite.body.sleeping = false;
                 } else {
                     enemy.createSprite(x, y);
                     enemy.setupPhysics();


### PR DESCRIPTION
This commit addresses two issues preventing enemy movement:

1. Corrected GameScene.updateEnemies() to call `enemy.enemy.update()` instead of `enemy.update()`. This ensures that the custom `Enemy` class's update logic (including movement and offscreen checks) is actually executed.

2. Enhanced Spawner.getEnemyFromPool() to explicitly reset the physics body state (`body.reset(x,y)`), set `isOffscreen = false`, and `body.sleeping = false` when an enemy is recycled from the pool. This ensures recycled enemies are immediately ready for movement.

These changes should resolve the problem of enemies not moving.